### PR TITLE
add etcd backend

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -25,6 +25,7 @@ type ConfigStore interface {
 func NewConfigStore(uri *url.URL) ConfigStore {
 	factory := map[string]func(*url.URL) ConfigStore{
 		"consul": NewConsulStore,
+		"etcd":   NewEtcdStore,
 	}[uri.Scheme]
 	if factory == nil {
 		log.Fatal("unrecognized config store backend: ", uri.Scheme)

--- a/etcd.go
+++ b/etcd.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"log"
+	"net/url"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+type EtcdStore struct {
+	client    *etcd.Client
+	waitIndex uint64
+}
+
+func NewEtcdStore(uri *url.URL) ConfigStore {
+	urls := make([]string, 0)
+	if uri.Host != "" {
+		urls = append(urls, "http://"+uri.Host)
+	}
+	return &EtcdStore{client: etcd.NewClient(urls)}
+}
+
+func (s *EtcdStore) List(path string) (list []string) {
+	resp, err := s.client.Get(path, false, true)
+	if err != nil {
+		log.Println("etcd:", err)
+		return
+	}
+	if resp.Node == nil {
+		return
+	}
+	if len(resp.Node.Nodes) == 0 {
+		list = append(list, string(resp.Node.Value))
+	} else {
+		for _, node := range resp.Node.Nodes {
+			list = append(list, string(node.Value))
+		}
+	}
+	return
+}
+
+func (s *EtcdStore) Get(path string) string {
+	resp, err := s.client.Get(path, false, false)
+	if err != nil {
+		log.Println("etcd:", err)
+		return ""
+	}
+	if resp.Node == nil {
+		return ""
+	}
+	return string(resp.Node.Value)
+}
+
+func (s *EtcdStore) Watch(path string) {
+	resp, err := s.client.Watch(path, s.waitIndex, true, nil, nil)
+	if err != nil {
+		log.Println("etcd:", err)
+	} else {
+		s.waitIndex = resp.EtcdIndex + 1
+	}
+}


### PR DESCRIPTION
At the bottom of the [Standard Mode readme section](https://github.com/progrium/ambassadord#standard-mode-aka-boring-but-useful-mode), there's an example using an etcd backend:

```
$ docker run -d progrium/ambassadord etcd://127.0.0.1:4001/path/to/backend/nodes
```

I tried to use it, but quickly realized it wasn't implemented yet. This should take care of that :)
