### PR TITLE
Fixed endless loop and added exponential backoff in case of errors

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -47,11 +47,12 @@ func (s *ConsulStore) Get(path string) string {
 	return string(kv.Value)
 }
 
-func (s *ConsulStore) Watch(path string) {
+func (s *ConsulStore) Watch(path string) error {
 	_, meta, err := s.client.KV().Get(path, &consulapi.QueryOptions{WaitIndex: s.waitIndex})
 	if err != nil {
 		log.Println("consul:", err)
 	} else {
 		s.waitIndex = meta.LastIndex
 	}
+	return err
 }


### PR DESCRIPTION
- Fixed endless loop when etcd returns "401: The event in requested index is outdated and cleared". Fix resets the waitIndex on each List()/Get() request.
- Added exponential backoff in configBackends.WatchToUpdate() goroutine to avoid DoS on etcd/consul in event of transient problems. Maximum backoff time is 30s.

Please note that the same problem could be present in the consul backend where a waitIndex is also used in ConsulStore.Watch(). I've got close to zero knowledge about consul and no easy way to test it, but if consul returns errors for too old waitIndexes (like etcd does) it could get stuck in a similar loop.
