### PR TITLE
[Reliability] Do not crash when container was destroyed on startup

### DIFF
--- a/connectable.go
+++ b/connectable.go
@@ -178,8 +178,10 @@ func setupContainer(id string) error {
 			log.Printf("setting iptables on %s \n", container.ID[:12])
 			shellCmd := strings.Join(cmds, " && ")
 			err := runNetCmd(container.ID, self.Image, shellCmd)
-			log.Printf("error setting iptables on %s: %s \n", container.ID[:12], err)
-			return err
+			if err != nil {
+				log.Printf("error setting iptables on %s: %s \n", container.ID[:12], err)
+				return err
+			}
 		}
 	}
 	return nil

--- a/connectable.go
+++ b/connectable.go
@@ -147,15 +147,17 @@ func proxyConn(conn net.Conn, addr string) {
 	<-done
 }
 
-func setupContainer(id string) {
+func setupContainer(id string) error {
 	re := regexp.MustCompile("connect\\[(\\d+)\\]")
 	client, err := docker.NewClient(endpoint)
 	if err != nil {
 		log.Println(err)
+		return err
 	}
 	container, err := client.InspectContainer(id)
 	if err != nil {
 		log.Println(err)
+		return err
 	}
 	if container.HostConfig.NetworkMode == "bridge" {
 		hasBackends := false
@@ -175,9 +177,13 @@ func setupContainer(id string) {
 		if hasBackends {
 			log.Printf("setting iptables on %s \n", container.ID[:12])
 			shellCmd := strings.Join(cmds, " && ")
-			assert(runNetCmd(container.ID, self.Image, shellCmd))
+			err := runNetCmd(container.ID, self.Image, shellCmd)
+			log.Printf("error setting iptables on %s: %s \n", container.ID[:12], err)
+			return err
 		}
 	}
+	return nil
+
 }
 
 func monitorContainers() {


### PR DESCRIPTION
Running a container with `docker run --rm -l connect[8000]=example.service any-image invalid-command` would cause connectable to crash upon trying to create a container in an invalid network(because the container had been destroyed). Now it just prints an error.