### PR TITLE
using start seems to be more reliable than create

### DIFF
--- a/connectable.go
+++ b/connectable.go
@@ -191,7 +191,7 @@ func monitorContainers() {
 	}
 	for msg := range events {
 		switch msg.Status {
-		case "create":
+		case "start":
 			go setupContainer(msg.ID)
 		}
 	}


### PR DESCRIPTION
When using `create` I seem to hit an error about the container not running. Using start seems to fix it. https://github.com/gliderlabs/connectable/issues/26