### PR TITLE
Updated Docker label format to be docker spec compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ With Resolvable running, it will have access to Consul DNS. It will be able to r
 
 All you have to do is specify a port to use and what you'd like to connect to as a label. For example:
 
-	connect[6000]=redis.service.consul
+	connect.6000=redis.service.consul
 
 With this label set, you can connect to Redis on localhost:6000. You can also specify multiple services:
 
 	$ docker run -d --name myservice \
-			-l connect[6000]=redis.service.consul \
-			-l connect[3306]=master.mysql.service.consul \
+			-l connect.6000=redis.service.consul \
+			-l connect.3306=master.mysql.service.consul \
 			example/myservice
 
 ## Load Balancing

--- a/connectable.go
+++ b/connectable.go
@@ -88,7 +88,7 @@ func inspectBackend(sourceIP, destPort string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	label := fmt.Sprintf("connect[%s]", destPort)
+	label := fmt.Sprintf("connect.%s", destPort)
 
 	// todo: cache, invalidate with container destroy events
 	containers, err := client.ListContainers(docker.ListContainersOptions{})


### PR DESCRIPTION
Fixes issue: https://github.com/gliderlabs/connectable/issues/30 where the docker label format is not compliant with the Docker label specification of containing only lower-cased alphanumeric characters, dots and dashes.
