### PR TITLE
Fix labels broken by #31

### DIFF
--- a/connectable.go
+++ b/connectable.go
@@ -148,7 +148,7 @@ func proxyConn(conn net.Conn, addr string) {
 }
 
 func setupContainer(id string) error {
-	re := regexp.MustCompile("connect\\[(\\d+)\\]")
+	re := regexp.MustCompile("connect\\.(\\d+)")
 	client, err := docker.NewClient(endpoint)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
PR #31 changes label format in [`inspectBackend`](https://github.com/gliderlabs/connectable/pull/31/files#diff-5960809bc74544d011e24d09327bad48R91), but not in [`setupContainer`](https://github.com/gliderlabs/connectable/blob/master/connectable.go#L151). This breaks Connectable because containers with labels in `connectable.xxxx` format get ignored. This PR fixes it.