### PR TITLE
Improve reliability of determining self

### DIFF
--- a/connectable.go
+++ b/connectable.go
@@ -214,12 +214,14 @@ func main() {
 	client, err := docker.NewClient(endpoint)
 	assert(err)
 
+	selfImageRe := regexp.MustCompile("(?:^|/)connectable(?:$|:)")
+
 	list, err := client.ListContainers(docker.ListContainersOptions{})
 	assert(err)
 	for _, listing := range list {
 		c, err := client.InspectContainer(listing.ID)
 		assert(err)
-		if c.Config.Hostname == os.Getenv("HOSTNAME") {
+		if c.Config.Hostname == os.Getenv("HOSTNAME") && selfImageRe.FindString(c.Config.Image) != "" {
 			self = c
 			if c.HostConfig.NetworkMode == "bridge" || c.HostConfig.NetworkMode == "default" {
 				fmt.Printf("# Setting iptables on connectable... ")


### PR DESCRIPTION
Currently Connectable assigns self to the last container in the list of running ones at the moment Connectable starts. This leads to unexpected results when there are multiple containers running at that moment.

This PR adds "magic" environment variable `IS_CONNECTABLE_SELF`, which must be set to `yes` in a  container that gets assigned to `self`.

This allows to start connectable when other containers are already running.

I also tried to do without magic variable by inspecting entrypoint, but that significantly complicates running development container.

**UPD**: I probably should clarify this a little. Without this PR, Connectable works just fine if you don't pass hostnames to your containers, because, in this case, each container gets unique auto-generated hostname. But, if you pass hostnames to your containers, e.g.

```
$ docker run --name my-container --hostname "$HOSTNAME" my-image
```

and pass the same hostname to Connectable, it will not work, because [this check](https://github.com/gliderlabs/connectable/blob/230f0f354e56281205ad94cf5614ebeb17e9aaf8/connectable.go#L222) will match not only Connectable, but also other containers with the same hostname.