### PR TITLE
Improve development experience

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,2 @@
 FROM gliderlabs/alpine:3.2
-ENV GOPATH /go
 RUN apk-install go git mercurial iptables
-COPY . /go/src/github.com/gliderlabs/connectable
-WORKDIR /go/src/github.com/gliderlabs/connectable
-RUN go get
-CMD go get \
-	&& go build -ldflags "-X main.Version dev" -o /bin/connectable \
-	&& exec /bin/connectable

--- a/run
+++ b/run
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+: "${DEV_IMAGE_TAG:=connectable:dev-env}"
+: "${DEV_CONTAINER_NAME:=connectable-dev}"
+
+exists() { # type name
+  docker inspect --type "$1" -f '{{.Id}}' "$2" >/dev/null 2>&1
+}
+
+if ! exists image "$DEV_IMAGE_TAG"; then
+  printf '\n==> %s\n\n' 'Building base image...'
+  docker build -t "$DEV_IMAGE_TAG" -f Dockerfile.dev .
+fi
+
+if ! exists container "$DEV_CONTAINER_NAME"; then
+  docker create >/dev/null -it --name "$DEV_CONTAINER_NAME" \
+    -h dev \
+    -e GOPATH=/go \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$(pwd)":/go/src/github.com/gliderlabs/connectable \
+    -w /go/src/github.com/gliderlabs/connectable \
+    "$DEV_IMAGE_TAG" sh -c '
+      run() { cmd=$1; shift; printf "\\n==> %s\\n\\n" "$cmd $*"; "$cmd" "$@"; }
+      set -e
+      run go get
+      run go build -ldflags "-X main.Version dev" -o /bin/connectable
+      run exec /bin/connectable'
+fi
+
+exec docker start -ia "$DEV_CONTAINER_NAME"


### PR DESCRIPTION
This PR adds a simple Posix-compliant Shell script that build base image and runs development container at once.

Apart from reducing the number of commands needed to run dev container, this script also reduces startup time because it reuses already-created development container and its base image.

So, starting dev container now is as simple as running

```
$ ./dev
```

The first launch will be slow because it will build base image and create dev container, but all subsequent launches will be very fast.

The only caveat is that you'll need to remove `connectable-dev` container each time you change arguments to `docker create` inside `dev` script, or change path of the repo directory:

```
$ docker rm connectable-dev
```
